### PR TITLE
Remove dangling geos_3.12.0.bbappend

### DIFF
--- a/recipes-navigation/geos/geos_3.12.0.bbappend
+++ b/recipes-navigation/geos/geos_3.12.0.bbappend
@@ -1,4 +1,0 @@
-
-# Fix nothing provides 'geoslib' for nanbield
-# master commit fixes in https://git.openembedded.org/meta-openembedded/commit/meta-oe/recipes-navigation/geos/geos_3.12.0.bb?id=405ee461078cfed493bd6ca06f922860be5081d0
-FILES:${PN}lib += "${libdir}/libgeos.so.*"


### PR DESCRIPTION
BB_DANGLINGAPPENS_WARNONLY directive is being removed from bitbake to work-around dangling commits.

geos has been updated to 3.12.1 since scarthgap.
Version 3.12.1 fixes the nothing provides 'geoslib' error, bbappend for 3.12.0 bbappend is no longer necessary.