### PR TITLE
layer.conf: LAYERSERIES_COMPAT set to whinlatter

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PRIORITY_ka-integration = "20"
 
 LAYERVERSION_ka-integration = "1"
 LAYERDEPENDS_ka-integration = "core tegra openembedded-layer meta-python"
-LAYERSERIES_COMPAT_ka-integration = "scarthgap walnascar styhead"
+LAYERSERIES_COMPAT_ka-integration = "whinlatter"
 
 # omegaconf needs host java to build itself, and it's not worth pulling in meta-java
 HOSTTOOLS += "java"


### PR DESCRIPTION
OE core layers switched layerseries to whinlatter due to potential disruptions caused by WORKDIR -> UNPACKDIR changes.